### PR TITLE
Update 90-libinput-model-quirks.hwdb

### DIFF
--- a/udev/90-libinput-model-quirks.hwdb
+++ b/udev/90-libinput-model-quirks.hwdb
@@ -225,8 +225,8 @@ libinput:mouse:input:b0003v046DpC408*
 libinput:name:*Lid Switch*:dmi:*svnMicrosoftCorporation:pnSurface3:*
  LIBINPUT_ATTR_LID_SWITCH_RELIABILITY=write_open
 
-# Surface 3 Type Cover keyboard
-libinput:name:*Microsoft Surface Type Cover Keyboard*:dmi:*svnMicrosoftCorporation:pnSurface3:*
+# Surface Type Cover keyboard
+libinput:name:*Microsoft Surface Type Cover Keyboard*:dmi:*svnMicrosoftCorporation:*
  LIBINPUT_ATTR_KEYBOARD_INTEGRATION=internal
 
 ##########################################


### PR DESCRIPTION
`LIBINPUT_ATTR_KEYBOARD_INTEGRATION=internal` should apply to Surface Type Cover attached to any Surface model, not just Surface 3. (Fixes, e.g., disable-touchpad-while-typing on other Surface models.)