### PR TITLE
libinput is implemented only in C

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('libinput', 'c', 'cpp',
+project('libinput', 'c',
 	version : '1.10.900',
 	license : 'MIT/Expat',
 	default_options : [ 'c_std=gnu99', 'warning_level=2' ],


### PR DESCRIPTION
Remove cpp from the project definition otherwise compilation will fail
if meson can't find a C++ compiler

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>