### PR TITLE
Revise Microsoft Surface Type Cover quirk to apply to all Surfaces

### DIFF
--- a/data/30-vendor-microsoft.quirks
+++ b/data/30-vendor-microsoft.quirks
@@ -5,9 +5,9 @@ MatchName=*Lid Switch*
 MatchDMIModalias=dmi:*svnMicrosoftCorporation:pnSurface3:*
 AttrLidSwitchReliability=write_open
 
-[Microsoft Surface 3 Type Cover Keyboard]
+[Microsoft Surface Type Cover Keyboard]
 MatchName=*Microsoft Surface Type Cover Keyboard*
-MatchDMIModalias=dmi:*svnMicrosoftCorporation:pnSurface3:*
+MatchDMIModalias=dmi:*svnMicrosoftCorporation:*
 AttrKeyboardIntegration=internal
 
 [Microsoft Nano Transceiver v2.0]


### PR DESCRIPTION
`LIBINPUT_ATTR_KEYBOARD_INTEGRATION=internal` should apply to Surface Type Cover attached to any Surface model, not just Surface 3. (Fixes, e.g., disable-touchpad-while-typing on other Surface models.)